### PR TITLE
Add position as possible value for :line

### DIFF
--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -15,7 +15,7 @@ defmodule NimbleParsec.Compiler do
 
     ## Options
 
-      * `:line` - the initial line, defaults to 1
+      * `:line` - the initial line or position `{line, offset}`, defaults to 1
       * `:byte_offset` - the initial byte offset, defaults to 0
       * `:context` - the initial context value. It will be converted
         to a map
@@ -38,11 +38,16 @@ defmodule NimbleParsec.Compiler do
 
     body =
       quote do
-        line = Keyword.get(opts, :line, 1)
-        offset = Keyword.get(opts, :byte_offset, 0)
         context = Map.new(Keyword.get(opts, :context, []))
+        byte_offset = Keyword.get(opts, :byte_offset, 0)
 
-        case unquote(:"#{name}__0")(binary, [], [], context, {line, offset}, offset) do
+        line =
+          case Keyword.get(opts, :line, 1) do
+            {_, _} = line -> line
+            line -> {line, byte_offset}
+          end
+
+        case unquote(:"#{name}__0")(binary, [], [], context, line, byte_offset) do
           {:ok, acc, rest, context, line, offset} ->
             {:ok, :lists.reverse(acc), rest, context, line, offset}
 

--- a/test/nimble_parsec_test.exs
+++ b/test/nimble_parsec_test.exs
@@ -1317,6 +1317,25 @@ defmodule NimbleParsecTest do
     end
   end
 
+  describe "continuing parser" do
+    defparsecp :digits, [?0..?9] |> ascii_char() |> times(min: 1) |> label("digits")
+    defparsecp :chars, [?a..?z] |> ascii_char() |> times(min: 1) |> label("chars")
+
+    test "returns ok" do
+      string = "123abc"
+      assert {:ok, '123', "abc" = rest, %{}, {1, 0} = line, byte_offset} = digits(string)
+      assert chars(rest, line: line, byte_offset: byte_offset) == {:ok, 'abc', "", %{}, {1, 0}, 6}
+    end
+
+    test "returns error" do
+      string = "123:abc"
+      assert {:ok, '123', ":abc" = rest, %{}, {1, 0} = line, byte_offset} = digits(string)
+
+      assert chars(rest, line: line, byte_offset: byte_offset) ==
+               {:error, "expected chars", ":abc", %{}, {1, 0}, 3}
+    end
+  end
+
   defp location(_rest, args, %{} = context, line, offset, tag) do
     {[{tag, args, line, offset}], context}
   end


### PR DESCRIPTION
This PR extends the `:line` option when a parser is calling.
```elixir
...
defparsecp :digits, ascii_char([?0..?9]) 
...
digits("657", line: {2, 4}, byte_offset: 6)
```
This is useful to setup the start of the parser to a specific `{line, offset}` and `byte_offset`.
