### PR TITLE
Updated documentation about position

### DIFF
--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -11,7 +11,9 @@ defmodule NimbleParsec.Compiler do
 
     Returns `{:ok, [token], rest, context, position, byte_offset}` or
     `{:error, reason, rest, context, line, byte_offset}` where `position`
-    describes the location of the #{name} (start position) as `{line, column_on_line}`.
+    describes the location of the #{name} (start position) as `{line, offset_to_start_of_line}`.
+    
+    To column where the error occurred can be inferred from `byte_offset - offset_to_start_of_line`.
 
     ## Options
 


### PR DESCRIPTION
Amended the documentation to clarify that `position` is `{line, byte_offset_to_start_of_line}` rather than `{line, column}` and clarifying how to calculate the error column.