### PR TITLE
Make the dep tuple easier to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Add `nimble_parsec` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:nimble_parsec, "~> 1.0"}]
+  [
+    {:nimble_parsec, "~> 1.0"}
+  ]
 end
 ```
 


### PR DESCRIPTION
Just a minor annoyance I noticed the last three times I reached for nimble_parsec :)