### PR TITLE
Fix documentation for utf8_string/3

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -825,14 +825,18 @@ defmodule NimbleParsec do
   end
 
   @doc ~S"""
-  Defines an ASCII string combinator with of exact length or `min` and `max`
+  Defines an UTF8 string combinator with of exact length or `min` and `max`
   codepoint length.
 
-  The `ranges` specify the allowed characters in the ASCII string.
-  See `ascii_char/2` for more information.
+  The `ranges` specify the allowed characters in the UTF8 string.
+  See `utf8_char/2` for more information.
 
   If you want a string of unknown size, use `utf8_string(ranges, min: 1)`.
   If you want a literal string, use `string/2`.
+
+  Note that the combinator matches on codepoints, not graphemes. Therefore
+  results may vary depending on whether the input is in `nfc` or `nfd`
+  normalized form.
 
   ## Examples
 


### PR DESCRIPTION
Updated documentation for utf8_string/3:

* change references from ASCII to UTF8 and 
* note that results may vary depending on Unicode normalisation
