### PR TITLE
Reverse inner combinators in lookahead and lookahead_not (fixes #92)

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1109,7 +1109,7 @@ defmodule NimbleParsec do
   @spec lookahead(t, t) :: t
   def lookahead(combinator \\ empty(), to_lookahead)
       when is_combinator(combinator) and is_combinator(to_lookahead) do
-    [{:lookahead, to_lookahead, :positive} | combinator]
+    [{:lookahead, Enum.reverse(to_lookahead), :positive} | combinator]
   end
 
   @doc ~S"""
@@ -1127,7 +1127,7 @@ defmodule NimbleParsec do
   @spec lookahead_not(t, t) :: t
   def lookahead_not(combinator \\ empty(), to_lookahead)
       when is_combinator(combinator) and is_combinator(to_lookahead) do
-    [{:lookahead, to_lookahead, :negative} | combinator]
+    [{:lookahead, Enum.reverse(to_lookahead), :negative} | combinator]
   end
 
   @doc """

--- a/test/nimble_parsec_test.exs
+++ b/test/nimble_parsec_test.exs
@@ -670,11 +670,11 @@ defmodule NimbleParsecTest do
     defparsecp :lookahead_with_inner_compound_combinator,
                lookahead(utf8_char([?a]) |> utf8_char([?b]) |> utf8_char([?c]))
 
-    defparsec :nested_lookahead_with_inner_compound_combinator,
-              lookahead(
-                utf8_char([?a])
-                |> lookahead(utf8_char([?b]) |> utf8_char([?c]))
-              )
+    defparsecp :nested_lookahead_with_inner_compound_combinator,
+               lookahead(
+                 utf8_char([?a])
+                 |> lookahead(utf8_char([?b]) |> utf8_char([?c]))
+               )
 
     test "matches inner combinators in order" do
       assert lookahead_with_inner_compound_combinator("abc") ==
@@ -738,11 +738,11 @@ defmodule NimbleParsecTest do
     defparsecp :lookahead_not_with_inner_compound_combinator,
                lookahead_not(utf8_char([?a]) |> utf8_char([?b]))
 
-    defparsec :nested_lookahead_not_with_inner_compound_combinator,
-              lookahead_not(
-                utf8_char([?a])
-                |> lookahead(utf8_char([?b]) |> utf8_char([?c]))
-              )
+    defparsecp :nested_lookahead_not_with_inner_compound_combinator,
+               lookahead_not(
+                 utf8_char([?a])
+                 |> lookahead(utf8_char([?b]) |> utf8_char([?c]))
+               )
 
     test "matches inner combinators in order" do
       assert lookahead_not_with_inner_compound_combinator("ab") ==

--- a/test/nimble_parsec_test.exs
+++ b/test/nimble_parsec_test.exs
@@ -667,6 +667,23 @@ defmodule NimbleParsecTest do
     defparsecp :lookahead_with_times,
                times(ascii_char([]) |> lookahead(ascii_char([?0..?9])), min: 1)
 
+    defparsecp :lookahead_with_inner_compound_combinator,
+               lookahead(utf8_char([?a]) |> utf8_char([?b]) |> utf8_char([?c]))
+
+    defparsec :nested_lookahead_with_inner_compound_combinator,
+              lookahead(
+                utf8_char([?a])
+                |> lookahead(utf8_char([?b]) |> utf8_char([?c]))
+              )
+
+    test "matches inner combinators in order" do
+      assert lookahead_with_inner_compound_combinator("abc") ==
+               {:ok, [], "abc", %{}, {1, 0}, 0}
+
+      assert nested_lookahead_with_inner_compound_combinator("abc") ==
+               {:ok, [], "abc", %{}, {1, 0}, 0}
+    end
+
     test "aborts choice on no match" do
       assert lookahead_with_choice_digits_first("a0") == {:ok, [first: 'a'], "0", %{}, {1, 0}, 1}
       assert lookahead_with_choice_digits_first("aa") == {:ok, [second: 'a'], "a", %{}, {1, 0}, 1}
@@ -717,6 +734,27 @@ defmodule NimbleParsecTest do
 
     defparsecp :lookahead_not_repeat_until,
                repeat(lookahead_not(string("3")) |> ascii_char([?0..?9]) |> ascii_char([?0..?9]))
+
+    defparsecp :lookahead_not_with_inner_compound_combinator,
+               lookahead_not(utf8_char([?a]) |> utf8_char([?b]))
+
+    defparsec :nested_lookahead_not_with_inner_compound_combinator,
+              lookahead_not(
+                utf8_char([?a])
+                |> lookahead(utf8_char([?b]) |> utf8_char([?c]))
+              )
+
+    test "matches inner combinators in order" do
+      assert lookahead_not_with_inner_compound_combinator("ab") ==
+               {:error,
+                "did not expect utf8 codepoint equal to 'a', followed by utf8 codepoint equal to 'b'",
+                "ab", %{}, {1, 0}, 0}
+
+      assert nested_lookahead_not_with_inner_compound_combinator("abc") ==
+               {:error,
+                "did not expect utf8 codepoint equal to 'a', followed by utf8 codepoint equal to 'b', followed by utf8 codepoint equal to 'c'",
+                "abc", %{}, {1, 0}, 0}
+    end
 
     test "aborts choice on match" do
       assert lookahead_not_with_choice_digits_first("a0") ==


### PR DESCRIPTION
After looking into #92, I think the problem may be that the `to_lookahead` arrays should be reversed, similarly as in `repeat`, `eventually`, etc. The snippet shared there, with or without the `|> debug()`, now has the same return value, so I hope this can close that issue.

Also, here is a more minimal snippet that illustrates the problem:

```elixir
defmodule Test do
  import NimbleParsec
  defparsec :parse, lookahead(utf8_char([?a]) |> utf8_char([?b]))
end

# Should match:

Test.parse("ab")

# but emits the error (expects the combinators in reverse order)

{:error,
 "expected utf8 codepoint equal to 'b', followed by utf8 codepoint equal to 'a'",
 "ab", %{}, {1, 0}, 0}
```
`lookahead_not` also behaves similarly.

Besides that test case, I also added 'nested' test cases which should maybe be dropped. I added them just because my first attempt at this issue added Enum.reverse elsewhere (in the compiler), which made the first test and the rest of the test suite pass, but not the nested case.