### PR TITLE
Add opts to typespec for repeat and choice

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -209,6 +209,7 @@ defmodule NimbleParsec do
   @type fargs :: {atom, args :: [term]}
   @type gen_times :: Range.t() | non_neg_integer() | nil
   @type gen_weights :: [pos_integer()] | nil
+	@type opts :: Keyword.t()
 
   # Steps to add a new combinator:
   #
@@ -1436,7 +1437,7 @@ defmodule NimbleParsec do
       #=> {:ok, [], "1234", %{}, {1, 0}, 0}
 
   """
-  @spec repeat(t, t) :: t
+  @spec repeat(t, t, opts) :: t
   def repeat(combinator \\ empty(), to_repeat, opts \\ [])
       when is_combinator(combinator) and is_combinator(to_repeat) and is_list(opts) do
     non_empty!(to_repeat, "repeat")
@@ -1669,7 +1670,7 @@ defmodule NimbleParsec do
   Instead of `repeat/2`, you may want to use `times/3` with the flags `:min`
   and `:max`.
   """
-  @spec choice(t, nonempty_list(t)) :: t
+  @spec choice(t, nonempty_list(t), opts) :: t
   def choice(combinator \\ empty(), [_, _ | _] = choices, opts \\ [])
       when is_combinator(combinator) do
     choices = Enum.map(choices, &Enum.reverse/1)

--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -209,7 +209,7 @@ defmodule NimbleParsec do
   @type fargs :: {atom, args :: [term]}
   @type gen_times :: Range.t() | non_neg_integer() | nil
   @type gen_weights :: [pos_integer()] | nil
-	@type opts :: Keyword.t()
+  @type opts :: Keyword.t()
 
   # Steps to add a new combinator:
   #


### PR DESCRIPTION
Both `repeat/3` and `choice/3` take a third optional parameter `opts` however `opts` is not included in the type spec. This PR adds an `opts` type and includes it in the type specs for `repeat/3` and `choice/3`.
