### PR TITLE
Add additional spec for repeat/{1,3}

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1465,6 +1465,7 @@ defmodule NimbleParsec do
 
   """
   @spec repeat(t) :: t
+  @spec repeat(t, t) :: t
   @spec repeat(t, opts) :: t
   @spec repeat(t, t, opts) :: t
   def repeat(combinator \\ empty(), to_repeat, opts \\ [])


### PR DESCRIPTION
Thanks to @emilianobovetti for updating the type specs. There is one more to be added to `repeat/{1,3}` and this PR adds it. 