### PR TITLE
Avoid compile warnings with negative lookahead

### DIFF
--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -188,7 +188,9 @@ defmodule NimbleParsec.Compiler do
       {next, step} = build_next(step, config)
       args = quote(do: [rest, acc, stack, context, line, offset])
       success_body = {next, [], args}
-      {_, [_bin | negative_head], _, failure_body} = build_catch_all(kind, current, combinators, config)
+
+      {_, [_bin | negative_head], _, failure_body} =
+        build_catch_all(kind, current, combinators, config)
 
       {success_body, failure_body, head} =
         if kind == :positive do

--- a/test/mix/tasks/nimble_parsec.compile_test.exs
+++ b/test/mix/tasks/nimble_parsec.compile_test.exs
@@ -14,6 +14,15 @@ defmodule Mix.Tasks.NimbleParsec.CompileTest do
         # parsec:Mix.Tasks.NimbleParsec.CompileTest.Parser
 
         import NimbleParsec
+
+        nested =
+          [string("am"), string("pm")]
+          |> choice()
+          |> lookahead_not(ascii_char([?s, ?p]))
+          |> unwrap_and_tag(:nested)
+
+        defparsec :lookahead_not_warning, string("foo") |> concat(optional(nested))
+
         defparsec :parse, integer(2)
         defparsecp :parsep, integer(2)
         defcombinator :combinator, integer(2)
@@ -34,6 +43,7 @@ defmodule Mix.Tasks.NimbleParsec.CompileTest do
         assert contents =~ "def parse(binary, opts \\\\ [])"
         assert contents =~ "defp parse__0("
         assert contents =~ "defp parsep(binary, opts \\\\ [])"
+        assert contents =~ "def lookahead_not_warning(binary, opts \\\\ [])"
         assert contents =~ "defp parsep__0("
         refute contents =~ "def combinator(binary, opts \\\\ [])"
         assert contents =~ "def combinator__0("
@@ -87,7 +97,7 @@ defmodule Mix.Tasks.NimbleParsec.CompileTest do
 
     test "assure max is old enough" do
       """
-          defparsec :max_zero, integer(max: 0) 
+          defparsec :max_zero, integer(max: 0)
       """
       |> assert_compilation_error(
         4,


### PR DESCRIPTION
Currently in some `lookahead_not` situations that is nested and tagged, there's a case where some generated code emits warnings of unused vars. This PR fixes those warnings.

I don't have a new assertion, but I did add some fixture code that exhibits the issue. I tried adjusting the `Mix.Task.run("compile")` call to treat warnings as errors to let that be the assertion, but it doesn't seem to be working as intended and compiling the generated code. Adjusting the `elixirc_paths` options for the project test env could fix this but maybe a bigger hammer than necessary.

When I add `debug: true` option to the new `lookahead_not_warning` fixture defparsec, this is what it outputs:

<details>
  <summary>Before (full)</summary>

```elixir
defp lookahead_not_warning__0(<<"foo", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
  lookahead_not_warning__1(rest, ["foo"] ++ acc, stack, context, comb__line, comb__offset + 3)
end

defp lookahead_not_warning__0(rest, _acc, _stack, context, line, offset) do
  {:error, "expected string \"foo\"", rest, context, line, offset}
end

defp lookahead_not_warning__1(rest, acc, stack, context, line, offset) do
  lookahead_not_warning__5(
  rest,
  [],
  [{rest, context, line, offset}, acc | stack],
  context,
  line,
  offset
)
end

defp lookahead_not_warning__3(rest, acc, [_, previous_acc | stack], context, line, offset) do
  lookahead_not_warning__2(rest, acc ++ previous_acc, stack, context, line, offset)
end

defp lookahead_not_warning__4(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
  lookahead_not_warning__3(rest, [], stack, context, line, offset)
end

defp lookahead_not_warning__5(rest, acc, stack, context, line, offset) do
  lookahead_not_warning__6(rest, [], [acc | stack], context, line, offset)
end

defp lookahead_not_warning__6(<<"am", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
  lookahead_not_warning__7(rest, ["am"] ++ acc, stack, context, comb__line, comb__offset + 2)
end

defp lookahead_not_warning__6(<<"pm", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
  lookahead_not_warning__7(rest, ["pm"] ++ acc, stack, context, comb__line, comb__offset + 2)
end

# THIS FUNCTION HAS THE WARNING vvvvv
defp lookahead_not_warning__6(rest, acc, stack, context, line, offset) do
  [acc | stack] = stack
lookahead_not_warning__4(rest, acc, stack, context, line, offset)
end

defp lookahead_not_warning__7(<<x0, _::binary>> = rest, acc, stack, context, line, offset) when x0 === 115 or x0 === 112 do
  [acc | stack] = stack
lookahead_not_warning__4(rest, acc, stack, context, line, offset)
end
# THIS FUNCTION HAS THE WARNING ^^^^^

defp lookahead_not_warning__7(rest, acc, stack, context, line, offset) do
  lookahead_not_warning__8(rest, acc, stack, context, line, offset)
end

defp lookahead_not_warning__8(rest, user_acc, [acc | stack], context, line, offset) do
  _ = user_acc

lookahead_not_warning__9(
  rest,
  [
    nested:
      case :lists.reverse(user_acc) do
        [one] -> one
        many -> raise "unwrap_and_tag/3 expected a single token, got: #{inspect(many)}"
      end
  ] ++ acc,
  stack,
  context,
  line,
  offset
)
end

defp lookahead_not_warning__9(rest, acc, [_, previous_acc | stack], context, line, offset) do
  lookahead_not_warning__2(rest, acc ++ previous_acc, stack, context, line, offset)
end

defp lookahead_not_warning__2(rest, acc, _stack, context, line, offset) do
  {:ok, acc, rest, context, line, offset}
end
```
</details>

<details>
<summary>After (snippet)</summary>

```elixir
# the acc head var is now underscored to avoid the compilation warning
defp lookahead_not_warning__6(rest, _acc, stack, context, line, offset) do
  [acc | stack] = stack
lookahead_not_warning__4(rest, acc, stack, context, line, offset)
end

defp lookahead_not_warning__7(<<x0, _::binary>> = rest, _acc, stack, context, line, offset) when x0 === 115 or x0 === 112 do
  [acc | stack] = stack
lookahead_not_warning__4(rest, acc, stack, context, line, offset)
end
```
</details>