### PR TITLE
Avoid compile warnings when using negative lookahead

### DIFF
--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -188,7 +188,9 @@ defmodule NimbleParsec.Compiler do
       {next, step} = build_next(step, config)
       args = quote(do: [rest, acc, stack, context, line, offset])
       success_body = {next, [], args}
-      {_, [_bin | negative_head], _, failure_body} = build_catch_all(kind, current, combinators, config)
+
+      {_, [_bin | negative_head], _, failure_body} =
+        build_catch_all(kind, current, combinators, config)
 
       {success_body, failure_body, head} =
         if kind == :positive do

--- a/test/mix/tasks/nimble_parsec.compile_test.exs
+++ b/test/mix/tasks/nimble_parsec.compile_test.exs
@@ -14,6 +14,15 @@ defmodule Mix.Tasks.NimbleParsec.CompileTest do
         # parsec:Mix.Tasks.NimbleParsec.CompileTest.Parser
 
         import NimbleParsec
+
+        nested =
+          [string("am"), string("pm")]
+          |> choice()
+          |> lookahead_not(ascii_char([?s, ?p]))
+          |> unwrap_and_tag(:nested)
+
+        defparsec :lookahead_not_warning, string("foo") |> concat(optional(nested))
+
         defparsec :parse, integer(2)
         defparsecp :parsep, integer(2)
         defcombinator :combinator, integer(2)
@@ -34,6 +43,7 @@ defmodule Mix.Tasks.NimbleParsec.CompileTest do
         assert contents =~ "def parse(binary, opts \\\\ [])"
         assert contents =~ "defp parse__0("
         assert contents =~ "defp parsep(binary, opts \\\\ [])"
+        assert contents =~ "def lookahead_not_warning(binary, opts \\\\ [])"
         assert contents =~ "defp parsep__0("
         refute contents =~ "def combinator(binary, opts \\\\ [])"
         assert contents =~ "def combinator__0("
@@ -87,7 +97,7 @@ defmodule Mix.Tasks.NimbleParsec.CompileTest do
 
     test "assure max is old enough" do
       """
-          defparsec :max_zero, integer(max: 0) 
+          defparsec :max_zero, integer(max: 0)
       """
       |> assert_compilation_error(
         4,

--- a/test/nimble_parsec_test.exs
+++ b/test/nimble_parsec_test.exs
@@ -821,7 +821,7 @@ defmodule NimbleParsecTest do
       assert lookahead_not_with_times("aaa0") == {:ok, 'aa', "a0", %{}, {1, 0}, 2}
     end
 
-    test "repeaet_until" do
+    test "repeat_until" do
       assert lookahead_not_repeat_until("1245") == {:ok, [?1, ?2, ?4, ?5], "", %{}, {1, 0}, 4}
       assert lookahead_not_repeat_until("12345") == {:ok, [?1, ?2], "345", %{}, {1, 0}, 2}
       assert lookahead_not_repeat_until("135") == {:ok, [?1, ?3], "5", %{}, {1, 0}, 2}


### PR DESCRIPTION
The generated code for a negative lookaheads have unused variables, causing warnings when trying to compile the resulting code.

This PR fixes that and adds some assertions to compile the generated code with the option `:warnings_as_errors`