### PR TITLE
Fix clause warning for integer combinator

### DIFF
--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -574,8 +574,8 @@ defmodule NimbleParsec.Compiler do
     {defs, inline, next, step, :catch_none}
   end
 
-  defp compile_time_repeat_while({:cont, quote(do: context)}), do: :cont
-  defp compile_time_repeat_while({:halt, quote(do: context)}), do: :halt
+  defp compile_time_repeat_while({:cont, {:context, _, __MODULE__}}), do: :cont
+  defp compile_time_repeat_while({:halt, {:context, _, __MODULE__}}), do: :halt
   defp compile_time_repeat_while(_), do: :none
 
   defp repeat_while(quoted, true_name, true_args, false_name, false_args) do


### PR DESCRIPTION
Fixes #109.

It seems this path is only reached when ElixirLS is compiling the code and the pattern match was failing. I'm not sure why this is happening, maybe it has to do with the difference in line numbers in the generated ast?