### PR TITLE
Fix typo in ignore/2 function doc

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1407,7 +1407,7 @@ defmodule NimbleParsec do
       defmodule MyParser do
         import NimbleParsec
 
-        defparsec :ignorable, string("T") |> ignore() |> integer(2, 2)
+        defparsec :ignorable, string("T") |> ignore() |> integer(2)
       end
 
       MyParser.ignorable("T12")


### PR DESCRIPTION
Updated documentation for ignore/2

 - Change from integer(2, 2) to integer(2)