### PR TITLE
Fix example string parser in repeat_while docs

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1604,6 +1604,7 @@ defmodule NimbleParsec do
                       utf8_char([])
                     ])
                   )
+                  |> ascii_char([?"])
                   |> reduce({List, :to_string, []})
       end
 


### PR DESCRIPTION
Adds a missing `ascii_char` call on the example string parser in `repeat_while`'s documentation

Closes #119 