### PR TITLE
parse_integers_using_lower_nibble

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -681,6 +681,13 @@ defmodule NimbleParsec do
     bin_segment(combinator, inclusive, exclusive, :integer)
   end
 
+  @spec integer_nibble() :: t
+  @spec integer_nibble(t) :: t
+  def integer_nibble(combinator \\ empty())
+      when is_combinator(combinator) do
+    [{:integer_nibble} | combinator]
+  end
+
   @doc ~S"""
   Defines a single UTF-8 codepoint in the given ranges.
 
@@ -802,7 +809,7 @@ defmodule NimbleParsec do
 
     min_max_compile_runtime_chars(
       combinator,
-      ascii_char([?0..?9]),
+      integer_nibble(),
       count,
       :__compile_integer__,
       :__runtime_integer__,
@@ -818,7 +825,7 @@ defmodule NimbleParsec do
 
     min_max_compile_runtime_chars(
       combinator,
-      ascii_char([?0..?9]),
+      integer_nibble(),
       opts,
       :__compile_integer__,
       :__runtime_integer__,
@@ -2035,7 +2042,7 @@ defmodule NimbleParsec do
     ast =
       quote do
         [head | tail] = unquote(reverse_now_or_later(acc))
-        [:lists.foldl(fn x, acc -> x - ?0 + acc * 10 end, head, tail)]
+        [:lists.foldl(fn x, acc -> x + acc * 10 end, head, tail)]
       end
 
     {:{}, [], [rest, ast, context]}
@@ -2045,7 +2052,7 @@ defmodule NimbleParsec do
     ast =
       quote do
         [head | tail] = unquote(reverse_now_or_later(acc))
-        [:lists.foldl(fn x, acc -> x - ?0 + acc * 10 end, head - ?0, tail)]
+        [:lists.foldl(fn x, acc -> x + acc * 10 end, head, tail)]
       end
 
     {:{}, [], [rest, ast, context]}
@@ -2065,11 +2072,11 @@ defmodule NimbleParsec do
   defp reverse_now_or_later(expr), do: quote(do: :lists.reverse(unquote(expr)))
 
   defp quoted_ascii_to_integer([var | vars], 1) do
-    [quote(do: unquote(var) - ?0) | quoted_ascii_to_integer(vars, 10)]
+    [quote(do: unquote(var)) | quoted_ascii_to_integer(vars, 10)]
   end
 
   defp quoted_ascii_to_integer([var | vars], index) do
-    [quote(do: (unquote(var) - ?0) * unquote(index)) | quoted_ascii_to_integer(vars, index * 10)]
+    [quote(do: unquote(var) * unquote(index)) | quoted_ascii_to_integer(vars, index * 10)]
   end
 
   defp quoted_ascii_to_integer([], _index) do

--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -846,6 +846,26 @@ defmodule NimbleParsec.Compiler do
     {:ok, [string], [], [string], %{metadata | line: line, offset: offset}}
   end
 
+  defp bound_combinator({:integer_nibble}, metadata) do
+    %{offset: offset, counter: counter} = metadata
+    {inputs, vars, guards} = build_integer_nibble(counter)
+    counter = counter + 1
+    offset = add_offset(offset, length(vars))
+
+    metadata = %{metadata | offset: offset, counter: counter}
+    {:ok, inputs, guards, vars, metadata}
+  end
+
+  @nibble_size 4
+  @integer_hi_nibble 3
+  defp build_integer_nibble(counter) do
+    lo_nibble = {:"x#{counter}", [], Elixir}
+    guard = quote(do: unquote(lo_nibble) < unquote(10))
+
+    {[{:"::", [], [@integer_hi_nibble, @nibble_size]}, {:"::", [], [lo_nibble, @nibble_size]}],
+     [lo_nibble], [guard]}
+  end
+
   defp bound_combinator({:bin_segment, inclusive, exclusive, modifier}, metadata) do
     %{line: line, offset: offset, counter: counter} = metadata
 
@@ -965,6 +985,10 @@ defmodule NimbleParsec.Compiler do
 
   defp label({:string, binary}) do
     "string #{inspect(binary)}"
+  end
+
+  defp label({:integer_nibble}) do
+    "ASCII character in the range \"0\" to \"9\""
   end
 
   defp label({:label, _combinator, label}) do


### PR DESCRIPTION
Currently integers are matched by pattern matching on number between 48 and 57 and then substracting 48 ascii code - that is integer 0
As 48 is 0x30 then we can just pattern match that the upper half of the byte is 3 and take the lower half - only checking if it's less than 10.
I prepared a livebook that compares both ways and there is 4-5% speed difference.
```
Comparison: 
half byte        3.04 K
original         2.93 K - 1.04x slower +13.23 μs
```
https://gist.github.com/dkuku/9004bbf92cb3b81e8ed6fe211b9c7fc6
I'm not sure how to measure the compilation time but it also should be a bit faster due to generating less code.