### PR TITLE
add bytes/2 combinator

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1804,7 +1804,7 @@ defmodule NimbleParsec do
   @spec bytes(pos_integer) :: t
   @spec bytes(t, pos_integer) :: t
   def bytes(combinator \\ empty(), count)
-    when is_combinator(combinator) and is_integer(count) and count > 0 do
+      when is_combinator(combinator) and is_integer(count) and count > 0 do
     [{:bytes, count} | combinator]
   end
 

--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1792,7 +1792,7 @@ defmodule NimbleParsec do
         defmodule MyParser do
           import NimbleParsec
 
-          defparsec :three_bytes = bytes(3)
+          defparsec :three_bytes, bytes(3)
         end
 
         MyParser.three_bytes("abc")

--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -237,6 +237,7 @@ defmodule NimbleParsec do
   @typep bound_combinator ::
            {:bin_segment, [inclusive_range], [exclusive_range], bin_modifier}
            | {:string, binary}
+           | {:bytes, pos_integer}
            | :eos
 
   @typep maybe_bound_combinator ::
@@ -380,6 +381,11 @@ defmodule NimbleParsec do
     generate(parsecs, mod, gen_times(t, Enum.random(0..max), mod, acc))
   end
 
+  defp generate([{:bytes, count} | parsecs], mod, acc) do
+    bytes = bytes_random(count)
+    generate(parsecs, mod, [bytes | acc])
+  end
+
   defp generate([], _mod, acc), do: Enum.reverse(acc)
 
   defp gen_export(mod, fun) do
@@ -436,6 +442,10 @@ defmodule NimbleParsec do
 
   defp weighted_random([_ | list], [weight | weights], chosen),
     do: weighted_random(list, weights, chosen - weight)
+
+  defp bytes_random(count) when is_integer(count) do
+    :crypto.strong_rand_bytes(count)
+  end
 
   @doc ~S"""
   Returns an empty combinator.
@@ -1772,6 +1782,30 @@ defmodule NimbleParsec do
   @spec optional(t, t) :: t
   def optional(combinator \\ empty(), optional) do
     choice(combinator, [optional, empty()])
+  end
+
+  @doc """
+  Defines a combinator to consume the next `n` bytes from the input.
+
+  ## Examples
+
+        defmodule MyParser do
+          import NimbleParsec
+
+          defparsec :three_bytes = bytes(3)
+        end
+
+        MyParser.three_bytes("abc")
+        #=> {:ok, ["abc"], "", %{}, {1, 0}, 3}
+
+        MyParser.three_bytes("ab")
+        #=> {:error, "expected 3 bytes", "ab", %{}, {1, 0}, 0}
+  """
+  @spec bytes(pos_integer) :: t
+  @spec bytes(t, pos_integer) :: t
+  def bytes(combinator \\ empty(), count)
+    when is_combinator(combinator) and is_integer(count) and count > 0 do
+    [{:bytes, count} | combinator]
   end
 
   ## Helpers

--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -900,6 +900,15 @@ defmodule NimbleParsec.Compiler do
     end
   end
 
+  defp bound_combinator({:bytes, count}, metadata) do
+    %{counter: counter, offset: offset} = metadata
+    {var, counter} = build_var(counter)
+    input = quote do unquote(var)::binary-size(unquote(count)) end
+    offset = add_offset(offset, count)
+    metadata = %{metadata | counter: counter, offset: offset}
+    {:ok, [input], [], [var], metadata}
+  end
+
   defp bound_combinator(_, _) do
     :error
   end
@@ -1023,6 +1032,10 @@ defmodule NimbleParsec.Compiler do
 
   defp label({:parsec, name}) do
     Atom.to_string(name)
+  end
+
+  defp label({:bytes, count}) do
+    "#{inspect(count)} bytes"
   end
 
   ## Bin segments

--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -903,7 +903,7 @@ defmodule NimbleParsec.Compiler do
   defp bound_combinator({:bytes, count}, metadata) do
     %{counter: counter, offset: offset} = metadata
     {var, counter} = build_var(counter)
-    input = quote do: unquote(var)::binary-size(unquote(count))
+    input = quote do: unquote(var) :: binary - size(unquote(count))
     offset = add_offset(offset, count)
     metadata = %{metadata | counter: counter, offset: offset}
     {:ok, [input], [], [var], metadata}

--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -903,7 +903,7 @@ defmodule NimbleParsec.Compiler do
   defp bound_combinator({:bytes, count}, metadata) do
     %{counter: counter, offset: offset} = metadata
     {var, counter} = build_var(counter)
-    input = quote do unquote(var)::binary-size(unquote(count)) end
+    input = quote do: unquote(var)::binary-size(unquote(count))
     offset = add_offset(offset, count)
     metadata = %{metadata | counter: counter, offset: offset}
     {:ok, [input], [], [var], metadata}

--- a/test/nimble_generator_test.exs
+++ b/test/nimble_generator_test.exs
@@ -107,6 +107,11 @@ defmodule NimbleGeneratorTest do
     assert times(string("foo"), min: 2, gen_times: 3) |> generate() == "foofoofoofoofoo"
   end
 
+  test "bytes" do
+    parsec = bytes(3)
+    assert byte_size(generate(parsec)) === 3
+  end
+
   defparsec :string_foo, string("foo"), export_metadata: true
   defparsec :string_choice, choice([parsec(:string_foo), string("bar")]), export_metadata: true
 

--- a/test/nimble_parsec_test.exs
+++ b/test/nimble_parsec_test.exs
@@ -1467,6 +1467,18 @@ defmodule NimbleParsecTest do
     end
   end
 
+  describe "bytes/2 combinator" do
+    defparsec :parse_bytes, bytes(3)
+
+    test "succeeds if input has sufficient bytes" do
+      assert parse_bytes("abc") == {:ok, ["abc"], "", %{}, {1, 0}, 3}
+    end
+
+    test "fails if input has insufficent bytes" do
+      assert parse_bytes("ab") == {:error, "expected 3 bytes", "ab", %{}, {1, 0}, 0}
+    end
+  end
+
   describe "continuing parser" do
     defparsecp :digits, [?0..?9] |> ascii_char() |> times(min: 1) |> label("digits")
     defparsecp :chars, [?a..?z] |> ascii_char() |> times(min: 1) |> label("chars")


### PR DESCRIPTION
This pull request adds a new `bytes/2` combinator ( #131). This combinator allows a user to pull the next `n` bytes from the input. It will compile to a `binary-size` pattern match on the input string and will return a parsing error if there are insufficient bytes.

@josevalim, I know that in #30, you proposed a `binary_size` combinator which seems to take this idea further. From what I can tell, it would add similar compile time optimizations to other bounded combinators. However, `bytes` was also included as a secondary combinator in that proposal.