### PR TITLE
Fix type of byte_offset

### DIFF
--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -28,7 +28,7 @@ defmodule NimbleParsec.Compiler do
           {:ok, [term], rest, context, line, byte_offset}
           | {:error, reason, rest, context, line, byte_offset}
         when line: {pos_integer, byte_offset},
-             byte_offset: pos_integer,
+             byte_offset: non_neg_integer,
              rest: binary,
              reason: String.t(),
              context: map


### PR DESCRIPTION
This fixes the type of `byte_offset` to allow for `0` without dialyzer warnings. When parsing a pattern starting at the beginning of a string, it's normal for this to be 0. Also, in the generated options, `:byte_offset` is 0.

https://github.com/dashbitco/nimble_parsec/blob/0ccc43e025b45dbb85d6f2f0ac0e2856ef6cd57f/lib/nimble_parsec/compiler.ex#L20