### PR TITLE
Update `optional` combinator documentation

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1776,7 +1776,7 @@ defmodule NimbleParsec do
   @doc """
   Marks the given combinator as `optional`.
 
-  It is equivalent to `choice([optional, empty()])`.
+  It is equivalent to `choice([combinator, empty()])`.
   """
   @spec optional(t) :: t
   @spec optional(t, t) :: t


### PR DESCRIPTION
Hello there,

A small PR/question regarding the `optional` combinator documentation.

I might be wrong, but it seems that `optional` combinator documentation should mention `combinator` instead of `optional` in this case:

```diff
-  It is equivalent to `choice([optional, empty()])`.
+  It is equivalent to `choice([combinator, empty()])`.
```

