### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
         include:
           - pair:
               elixir: 1.12.3
-              otp: 23.3
+              otp: 22.3
           - pair:
-              elixir: 1.15.7
-              otp: 26.1
+              elixir: 1.17.1
+              otp: 27.0
             lint: lint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # NimbleParsec
 
-[Online Documentation](https://hexdocs.pm/nimble_parsec).
+[![CI](https://github.com/dashbitco/nimble_parsec/actions/workflows/ci.yml/badge.svg)](https://github.com/dashbitco/nimble_parsec/actions/workflows/ci.yml)
+[![Module Version](https://img.shields.io/hexpm/v/nimble_parsec.svg)](https://hex.pm/packages/nimble_parsec)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/nimble_parsec)
 
 <!-- MDOC !-->
 


### PR DESCRIPTION
See https://hexdocs.pm/elixir/1.17.1/compatibility-and-deprecations.html

List of changes:
- use Erlang (22 and 27) and Elixit (~1.13~ 1.12 and 1.17) in GitHub CI.
- add related CI and Hex badges
- ~set minimum Elixir version to 1.13~