### PR TITLE
Fix deprecation warning on SimpleXML example

### DIFF
--- a/examples/simple_xml.exs
+++ b/examples/simple_xml.exs
@@ -25,11 +25,11 @@ defmodule SimpleXML do
                  |> concat(closing_tag)
                  |> post_traverse(:match_and_emit_tag)
 
-  defp match_and_emit_tag(_rest, [tag, [tag, text]], context, _line, _offset),
-    do: {[{String.to_atom(tag), [], text}], context}
+  defp match_and_emit_tag(rest, [tag, [tag, text]], context, _line, _offset),
+    do: {rest, [{String.to_atom(tag), [], text}], context}
 
-  defp match_and_emit_tag(_rest, [tag, [tag | nodes]], context, _line, _offset),
-    do: {[{String.to_atom(tag), [], nodes}], context}
+  defp match_and_emit_tag(rest, [tag, [tag | nodes]], context, _line, _offset),
+    do: {rest, [{String.to_atom(tag), [], nodes}], context}
 
   defp match_and_emit_tag(_rest, [opening, [closing | _]], _context, _line, _offset),
     do: {:error, "closing tag #{inspect(closing)} did not match opening tag #{inspect(opening)}"}


### PR DESCRIPTION
 > warning: returning a two-element tuple {acc, context} in pre_traverse/post_traverse
 > is deprecated, please return {rest, acc, context} instead
 >   SimpleXML.node__31/6
 >   SimpleXML.parse__0/6
 >   SimpleXML.parse/2
 >   examples/simple_xml.exs:50: anonymous fn/1 in :elixir_compiler_2.__FILE__/1
 >   (elixir 1.17.0-rc.1) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
 >   (elixir 1.17.0-rc.1) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2