### PR TITLE
Support Elixir 1.18 in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.12.3
-              otp: 22.3
+              elixir: "1.12"
+              otp: "22"
           - pair:
-              elixir: 1.17.1
-              otp: 27.0
+              elixir: "1.18"
+              otp: "27"
             lint: lint
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             deps


### PR DESCRIPTION
Additional changes:
- bump GitHub Actions
- specify versions as strings, not numbers, see https://github.com/erlef/setup-beam?tab=readme-ov-file#specify-versions-as-strings-not-numbers
- use major versions which resolves to latest version